### PR TITLE
Improve tagline and discord-tag readability

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -238,7 +238,8 @@ main {
 	font-size: 0.75rem;
 	letter-spacing: 0.3em;
 	text-transform: uppercase;
-	color: var(--muted);
+	color: var(--fg);
+	opacity: 0.7;
 	margin-top: -4px;
 }
 
@@ -305,9 +306,9 @@ main {
 .discord-tag {
 	font-size: 0.65rem;
 	letter-spacing: 0.2em;
-	color: var(--muted);
+	color: var(--fg);
 	margin-top: 8px;
-	opacity: 0.6;
+	opacity: 0.5;
 }
 
 .audio-toggle {


### PR DESCRIPTION
Switches tagline and discord-tag from `var(--muted)` to `var(--fg)` with reduced opacity for better contrast against the background video.

Closes #1